### PR TITLE
stop syncing user properties to firestore Users collection, closes #34

### DIFF
--- a/app/src/main/java/com/hfad/findandplayA/MainActivity.java
+++ b/app/src/main/java/com/hfad/findandplayA/MainActivity.java
@@ -14,7 +14,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_slot_machine);
+        setContentView(R.layout.activity_main);
 
         if( ! Auth.isLoggedIn() ){
             // load login activity

--- a/app/src/main/java/com/hfad/findandplayA/viewmodels/User.java
+++ b/app/src/main/java/com/hfad/findandplayA/viewmodels/User.java
@@ -105,7 +105,7 @@ public class User {
                         // since task is successful
                         link = Objects.requireNonNull(task.getResult()).getUser();
                         refreshPropertiesFromAuth();
-                        updateUserMetadata(ok -> then.accept(true));
+                        then.accept(true);
                     }
                 });
     }
@@ -125,26 +125,7 @@ public class User {
                     return;
                 }
 
-                updateUserMetadata(ok -> then.accept(true));
-            }
-        });
-    }
-
-    private void updateUserMetadata(Consumer<Boolean> then)
-    {
-        FirebaseFirestore firebaseFirestore = FirebaseFirestore.getInstance();
-        DocumentReference ref = firebaseFirestore.collection("Users").document(getUid());
-
-        Map<String, Object> data = new HashMap<>();
-        data.put("email", email);
-        data.put("displayName", displayName);
-        data.put("photoUri", photoUri);
-
-        ref.set(data).addOnCompleteListener(new OnCompleteListener<Void>() {
-            @RequiresApi(api = Build.VERSION_CODES.N)
-            @Override
-            public void onComplete(@NonNull Task<Void> task) {
-                then.accept(task.isSuccessful());
+                then.accept(true);
             }
         });
     }


### PR DESCRIPTION
I had a discussion with Jamie and figured out everyone who signs up and signs in is actually an admin user. The players (children) will be added by said admin later via app screens, and saved to Firestore collections.

I originally thought everybody has to sign up and login, that's why I started syncing custom user metadata to Firestore, since you can't save additional fields with the auth functions, and reading other users data requires a REST API that uses the admin SDK.